### PR TITLE
Ec2 subdomain

### DIFF
--- a/nova.sh
+++ b/nova.sh
@@ -151,7 +151,7 @@ if [ "$CMD" == "run" ]; then
 
     # nova api crashes if we start it with a regular screen command,
     # so send the start command by forcing text into the window.
-    screen_it api "$VENV$NOVA_DIR/bin/nova-api --flagfile=/etc/nova/nova-manage.conf"
+    screen_it api "$VENV$NOVA_DIR/bin/nova-api --flagfile=/etc/nova/nova-manage.conf --FAKE_subdomain=ec2"
     screen_it objectstore "$VENV$NOVA_DIR/bin/nova-objectstore --flagfile=/etc/nova/nova-manage.conf"
     screen_it compute "$VENV$NOVA_DIR/bin/nova-compute --flagfile=/etc/nova/nova-manage.conf"
     screen_it network "$VENV$NOVA_DIR/bin/nova-network --flagfile=/etc/nova/nova-manage.conf"


### PR DESCRIPTION
added a --FAKE_subdomain=ec2 to the api service

I don't know if this is the best way to fix this, but the api server fails with 404s if you just follow the readme
