### PR TITLE
Import error preventing nova-compute from running

### DIFF
--- a/nova.sh
+++ b/nova.sh
@@ -81,7 +81,8 @@ if [ "$CMD" == "install" ]; then
     sudo modprobe kvm
     sudo /etc/init.d/libvirt-bin restart
     sudo apt-get install -y python-twisted python-sqlalchemy python-mox python-greenlet python-carrot
-    sudo apt-get install -y python-daemon python-eventlet python-gflags python-ipy python-cheetah
+    sudo apt-get install -y python-daemon python-eventlet python-gflags python-ipy 
+    sudo apt-get install -y python-cheetah
     sudo apt-get install -y python-libvirt python-libxml2 python-routes
     if [ "$USE_MYSQL" == 1 ]; then
         cat <<MYSQL_PRESEED | debconf-set-selections


### PR DESCRIPTION
When running nova-compute with the basic install I got this

Traceback (most recent call last):
  File "/opt/nova/bin/nova-compute", line 44, in <module>
    service.serve()
  File "/opt/nova/nova/service.py", line 229, in serve
    x.start()
  File "/opt/nova/nova/service.py", line 76, in start
    **self.saved_kwargs)
  File "/opt/nova/nova/compute/manager.py", line 66, in **init**
    self.driver = utils.import_object(compute_driver)
  File "/opt/nova/nova/utils.py", line 63, in import_object
    cls = import_class(import_str)
  File "/opt/nova/nova/utils.py", line 54, in import_class
    raise exception.NotFound(_('Class %s cannot be found') % class_str)
nova.exception.NotFound: Class get_connection cannot be found

I traced it down to a missing dependency which is supposed to be installed by the script. By running the program with "bash -x" I found out that it wasn't installing even though the python-cheetah dependency was listed. I moved that to a new line and that fixed it on my server. I wanted the error to be reported on a public site visible from Google because it was a little hard to track down.

Hope this helps!
