### PR TITLE
No more RabbitMQ dialog on install

### DIFF
--- a/nova.sh
+++ b/nova.sh
@@ -67,6 +67,8 @@ if [ "$CMD" == "install" ]; then
     sudo apt-get update
     sudo apt-get install -y dnsmasq-base kpartx kvm gawk iptables ebtables
     sudo apt-get install -y user-mode-linux kvm libvirt-bin
+    # Bypass  RabbitMQ "OK" dialog 
+    echo "rabbitmq-server rabbitmq-server/upgrade_previous note" | sudo debconf-set-selections
     sudo apt-get install -y screen euca2ools vlan curl rabbitmq-server
     sudo apt-get install -y lvm2 iscsitarget open-iscsi
     sudo apt-get install -y socat unzip


### PR DESCRIPTION
With this patch, RabbitMQ dialog should no longer appear when doing "./nova.sh install".
