### PR TITLE
minor improvements for using screen and lxc

### DIFF
--- a/nova.sh
+++ b/nova.sh
@@ -11,16 +11,15 @@ else
     DIRNAME=${2:-nova}
 fi
 
+# function definitions
+function screen_it {
+    screen -r "$SCREEN_NAME" -x -X screen -t $1
+    screen -r "$SCREEN_NAME" -x -p $1 -X stuff "$2$NL"
+}
+# end function definitions
+
 NOVA_DIR=$DIR/$DIRNAME
 GLANCE_DIR=$DIR/glance
-
-if [ ! -n "$HOST_IP" ]; then
-    # NOTE(vish): This will just get the first ip in the list, so if you
-    #             have more than one eth device set up, this will fail, and
-    #             you should explicitly set HOST_IP in your environment
-    HOST_IP=`LC_ALL=C ifconfig  | grep -m 1 'inet addr:'| cut -d: -f2 | awk '{print $1}'`
-fi
-
 USE_MYSQL=${USE_MYSQL:-1}
 INTERFACE=${INTERFACE:-eth0}
 FLOATING_RANGE=${FLOATING_RANGE:-10.6.0.0/27}
@@ -38,6 +37,13 @@ NET_MAN=${NET_MAN:-VlanManager}
 #             below but make sure that the interface doesn't already have an
 #             ip or you risk breaking things.
 # FLAT_INTERFACE=eth0
+if [ ! -n "$HOST_IP" ]; then
+    # NOTE(vish): This will just get the first ip in the list, so if you
+    #             have more than one eth device set up, this will fail, and
+    #             you should explicitly set HOST_IP in your environment
+    HOST_IP=`LC_ALL=C ifconfig  | grep -m 1 'inet addr:'| cut -d: -f2 | awk '{print $1}'`
+fi
+
 
 if [ "$USE_MYSQL" == 1 ]; then
     SQL_CONN=mysql://root:$MYSQL_PASS@localhost/nova
@@ -111,11 +117,6 @@ MYSQL_PRESEED
 fi
 
 NL=`echo -ne '\015'`
-
-function screen_it {
-    screen -r "$SCREEN_NAME" -x -X screen -t $1
-    screen -r "$SCREEN_NAME" -x -p $1 -X stuff "$2$NL"
-}
 
 if [ "$CMD" == "run" ] || [ "$CMD" == "run_detached" ]; then
   # check for existing screen, exit if present

--- a/nova.sh
+++ b/nova.sh
@@ -16,6 +16,8 @@ function screen_it {
     screen -r "$SCREEN_NAME" -x -X screen -t $1
     screen -r "$SCREEN_NAME" -x -p $1 -X stuff "$2$NL"
 }
+function error() { echo "$@" 1>&2; }
+function fail() { [ $# -eq 0 ] || error "$@" ; exit 1; }
 # end function definitions
 
 NOVA_DIR=$DIR/$DIRNAME

--- a/nova.sh
+++ b/nova.sh
@@ -142,7 +142,7 @@ if [ "$CMD" == "run" ] || [ "$CMD" == "run_detached" ]; then
        echo "none /cgroups cgroup cpuacct,memory,devices,cpu,freezer,blkio 0 0" |
          tee -a /etc/fstab
     fi
-    [ -n "$(awk '$2 == "/cgroups" && { print $2 }' /proc/mounts)" ] ||
+    [ -n "$(awk '$2 == "/cgroups" { print $2 }' /proc/mounts)" ] ||
       mount /cgroups
   fi
 

--- a/nova.sh
+++ b/nova.sh
@@ -134,6 +134,18 @@ if [ "$CMD" == "run" ] || [ "$CMD" == "run_detached" ]; then
     screen -r "$SCREEN_NAME" -X hardstatus alwayslastline "%-Lw%{= BW}%50>%n%f* %t%{-}%+Lw%< %= %H"
   fi
 
+
+  if [ "$LIBVIRT_TYPE" = "lxc" ]; then
+    if ent=$(awk '$2 == "/cgroups" { print $2 }' /etc/fstab) &&
+       [ -z "$ent" ]; then
+       mkdir -p /cgroups
+       echo "none /cgroups cgroup cpuacct,memory,devices,cpu,freezer,blkio 0 0" |
+         tee -a /etc/fstab
+    fi
+    [ -n "$(awk '$2 == "/cgroups" && { print $2 }' /proc/mounts)" ] ||
+      mount /cgroups
+  fi
+
   cat >$NOVA_DIR/bin/nova.conf << NOVA_CONF_EOF
 --verbose
 --nodaemon


### PR DESCRIPTION
2 things here:

improvements to usage of screen, and add status line.
- uses '-r' rather than -S in 'screen_it'.  -r more directly
  says that we're expecting to re-attach to an existing screen.
- adds the status line suggested at
  http://wiki.openstack.org/NovaInstall/DevInstallScript
  which can then be configured off by setting SCREEN_STATUS=0
- verifies that an existing screen session does not exist
  before trying to create a new one.  this would occur if the
  user detached from the screen and then ran 'run' again.

setting up of /etc/fstab and /cgroups for lxc usage
