### PR TITLE
Make nova.sh install noninteractive

### DIFF
--- a/nova.sh
+++ b/nova.sh
@@ -96,7 +96,7 @@ fi
 # You should only have to run this once
 if [ "$CMD" == "install" ]; then
     sudo apt-get install -y python-software-properties
-    sudo add-apt-repository ppa:nova-core/trunk
+    yes|sudo add-apt-repository ppa:nova-core/trunk
     sudo apt-get update
     sudo apt-get install -y dnsmasq-base kpartx kvm gawk iptables ebtables
     sudo apt-get install -y user-mode-linux kvm libvirt-bin


### PR DESCRIPTION
There's just one point where nova.sh install prompts me at the moment. I'm doing some dev environment automation so it would be nice if it didn't prompt me here.
